### PR TITLE
Feature/dynamic input forms

### DIFF
--- a/src/containers/pipelines/pipeline-runs/pipeline-form/form-builder.js
+++ b/src/containers/pipelines/pipeline-runs/pipeline-form/form-builder.js
@@ -56,7 +56,7 @@ const FormLabel = styled.label`
 `;
 
 const FormBuilder = ({
-  field, fieldName, handleChange, value, type,
+  field, fieldName, fieldId, handleChange, value, type,
 }) => {
   // simple dropdown tooltip
   const menu = (
@@ -76,7 +76,7 @@ const FormBuilder = ({
         </FormLabel>
         <input
           type="text"
-          id={fieldName}
+          id={fieldId}
           name={fieldName}
           value={value.value}
           onChange={(e) => handleChange(e)}
@@ -98,7 +98,7 @@ const FormBuilder = ({
         </FormLabel>
         <input
           type="text"
-          id={fieldName}
+          id={fieldId}
           name={fieldName}
           value={value.value}
           onChange={(e) => handleChange(e)}
@@ -118,7 +118,7 @@ const FormBuilder = ({
         </FormLabel>
         <input
           type="text"
-          id={fieldName}
+          id={fieldId}
           name={fieldName}
           value={value.value}
           onChange={(e) => handleChange(e)}
@@ -138,7 +138,7 @@ const FormBuilder = ({
         </FormLabel>
         <input
           type="text"
-          id={fieldName}
+          id={fieldId}
           name={fieldName}
           value={value.value}
           onChange={(e) => handleChange(e)}
@@ -157,7 +157,7 @@ const FormBuilder = ({
         </FormLabel>
         <input
           type="number"
-          id={fieldName}
+          id={fieldId}
           name={fieldName}
           value={value.value}
           onChange={(e) => handleChange(e)}
@@ -177,7 +177,7 @@ const FormBuilder = ({
         </FormLabel>
         <input
           type="number"
-          id={fieldName}
+          id={fieldId}
           name={fieldName}
           onChange={(e) => handleChange(e)}
         />
@@ -205,7 +205,7 @@ const FormBuilder = ({
         </FormLabel>
         <input
           type="text"
-          id={fieldName}
+          id={fieldId}
           name={fieldName}
           value={value.value}
           onChange={(e) => handleChange(e)}
@@ -224,7 +224,7 @@ const FormBuilder = ({
         </FormLabel>
         <input
           type="number"
-          id={fieldName}
+          id={fieldId}
           name={fieldName}
           value={value.value}
           onChange={(e) => handleChange(e)}
@@ -244,7 +244,7 @@ const FormBuilder = ({
         </FormLabel>
         <input
           type="number"
-          id={fieldName}
+          id={fieldId}
           name={fieldName}
           value={value.value}
           onChange={(e) => handleChange(e)}
@@ -280,6 +280,7 @@ FormBuilder.propTypes = {
     description: PropTypes.string.isRequired,
   }).isRequired,
   fieldName: PropTypes.string.isRequired,
+  fieldId: PropTypes.string.isRequired,
   handleChange: PropTypes.func.isRequired,
   value: PropTypes.shape({
     value: PropTypes.oneOfType([

--- a/src/containers/pipelines/pipeline-runs/pipeline-form/pipelineForm.js
+++ b/src/containers/pipelines/pipeline-runs/pipeline-form/pipelineForm.js
@@ -177,16 +177,21 @@ const PipelineForm = ({ config, formType, onInputFormSubmit }) => {
           {formBuilder.map((item) => {
             const field = config[item];
             let fieldName;
+            let fieldId = '';
             if (config[item].prompt === undefined) {
               fieldName = item;
             } else {
               fieldName = config[item].prompt;
+            }
+            if (typeof (item) === 'string') {
+              fieldId = item;
             }
             return (
               <FormBuilder
                 key={item}
                 type={fType}
                 field={field}
+                fieldId={fieldId}
                 fieldName={fieldName}
                 value={toCsv[item]}
                 handleChange={handleChange}

--- a/src/containers/pipelines/pipeline-runs/start-run-popup/index.js
+++ b/src/containers/pipelines/pipeline-runs/start-run-popup/index.js
@@ -252,7 +252,7 @@ const StartRunPopup = ({
           textcolor="lightBlue"
           onClick={handleOpenPiplineClick}
         >
-          Pipline Description
+          Pipeline Description
         </StyledButton>,
       ]}
       onOk={handleOk}

--- a/src/containers/pipelines/pipeline-runs/start-run-popup/index.js
+++ b/src/containers/pipelines/pipeline-runs/start-run-popup/index.js
@@ -252,7 +252,7 @@ const StartRunPopup = ({
           textcolor="lightBlue"
           onClick={handleOpenPiplineClick}
         >
-          Pipeline Description
+          Help
         </StyledButton>,
       ]}
       onOk={handleOk}


### PR DESCRIPTION
#Issue
Forms were no longer accepting inputs when prompts were included that overrode the default form name.

#Solution
Adjusted the implementation of the form id to maintain consistency and allow changing the form name without impacting the reference code. 