### PR TITLE
Enhancements/upload multiple fields

### DIFF
--- a/src/containers/pipelines/pipeline-runs/pipeline-form/form-builder.js
+++ b/src/containers/pipelines/pipeline-runs/pipeline-form/form-builder.js
@@ -57,9 +57,9 @@ const AppDropdownMenuItem = styled(Menu.Item)`
 `;
 
 const UploadZone = styled.div`
-&:hover {
-  background-color: green;
-}
+  &.dragged {
+    background-color: ${colors.lightBlue};
+  }
 `;
 
 const FormLabel = styled.label`
@@ -72,6 +72,12 @@ const FormSelect = styled.select`
 
 const FormInput = styled.input`
   min-width: 10rem;
+  &.dragged {
+    background-color: #e0ffff;
+  }
+  &.overMax {
+    background-color: #f0e68c;
+  }
 `;
 
 const FormBuilder = ({
@@ -152,7 +158,6 @@ const FormBuilder = ({
 
   const onUploadZoneDragOverOrEnter = (e) => {
     e.preventDefault();
-
     if (!uploadZoneDragged) setUploadZoneDragged(true);
   };
 
@@ -227,14 +232,17 @@ const FormBuilder = ({
   }
 
   if (isUpload) {
+    const overMax = field.isOverMax ? 'overMax' : '';
     return (
       <>
         <UploadZone
           onDragOver={onUploadZoneDragOverOrEnter}
           onDragEnter={onUploadZoneDragOverOrEnter}
           onDragLeave={onUploadZoneDragLeave}
-          onDrop={(e) => handleDrop(e, fieldId, field.space_delimited, field.upload_max)}
-          className={uploadZoneDragged ? 'dragged' : ''}
+          onDrop={(e) => {
+            onUploadZoneDragLeave();
+            return handleDrop(e, fieldId, field.space_delimited, field.upload_max);
+          }}
         >
           <FormLabel style={{
             minWidth: '10rem',
@@ -266,6 +274,7 @@ const FormBuilder = ({
             value={value.value}
             defaultChecked={boolDefault}
             onChange={(e) => handleChange(e)}
+            className={uploadZoneDragged ? 'dragged' : overMax}
           />
           <AppDropdown overlay={menu} trigger="click">
             <QmarkOutlined />
@@ -335,6 +344,7 @@ FormBuilder.propTypes = {
     choices: PropTypes.string.isRequired,
     isValidated: PropTypes.bool.isRequired,
     space_delimited: PropTypes.bool.isRequired,
+    isOverMax: PropTypes.bool.isRequired,
     upload_max: PropTypes.number.isRequired,
   }).isRequired,
   fieldName: PropTypes.string.isRequired,

--- a/src/containers/pipelines/pipeline-runs/pipeline-form/form-builder.js
+++ b/src/containers/pipelines/pipeline-runs/pipeline-form/form-builder.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Dropdown, Menu } from 'antd';
@@ -56,6 +56,12 @@ const AppDropdownMenuItem = styled(Menu.Item)`
   }
 `;
 
+const UploadZone = styled.div`
+&:hover {
+  background-color: green;
+}
+`;
+
 const FormLabel = styled.label`
   min-width: 15rem;
 `;
@@ -69,8 +75,9 @@ const FormInput = styled.input`
 `;
 
 const FormBuilder = ({
-  field, fieldName, fieldId, handleChange, value, type, handleChangeSelect,
+  field, fieldName, fieldId, handleChange, value, type, handleChangeSelect, handleDrop,
 }) => {
+  const [uploadZoneDragged, setUploadZoneDragged] = useState(false);
   // simple dropdown tooltip
   const menu = (
     <AppDropdownMenu>
@@ -143,6 +150,16 @@ const FormBuilder = ({
       fieldType = 'text';
   }
 
+  const onUploadZoneDragOverOrEnter = (e) => {
+    e.preventDefault();
+
+    if (!uploadZoneDragged) setUploadZoneDragged(true);
+  };
+
+  const onUploadZoneDragLeave = () => {
+    if (uploadZoneDragged) setUploadZoneDragged(false);
+  };
+
   // looking at merging multi select and select for cleaner/consistent implementation and styling
   if (isMultiSelect) {
     const options = [];
@@ -212,41 +229,48 @@ const FormBuilder = ({
   if (isUpload) {
     return (
       <>
-        <FormLabel style={{
-          minWidth: '10rem',
-          color: field.isValidated ? 'black' : 'pink',
-        }}
+        <UploadZone
+          onDragOver={onUploadZoneDragOverOrEnter}
+          onDragEnter={onUploadZoneDragOverOrEnter}
+          onDragLeave={onUploadZoneDragLeave}
+          onDrop={(e) => handleDrop(e, fieldId, field.space_delimited, field.upload_max)}
+          className={uploadZoneDragged ? 'dragged' : ''}
         >
-          {fieldName}
-        </FormLabel>
-        <StyledButton
-          type="text"
-          size="middle"
-          textcolor="lightBlue"
-          style={{ minWidth: '5rem' }}
-        >
-          <label htmlFor={fieldId}>
-            <UploadBox />
-          </label>
-        </StyledButton>
-        <FormInput
-          type={fieldType}
-          id={fieldId}
-          name={fieldName}
-          onChange={(e) => handleChange(e)}
-        />
-        <FormInput
-          type="text"
-          id={fieldId}
-          name={fieldName}
-          value={value.value}
-          defaultChecked={boolDefault}
-          onChange={(e) => handleChange(e)}
-        />
-        <AppDropdown overlay={menu} trigger="click">
-          <QmarkOutlined />
-        </AppDropdown>
-        <br />
+          <FormLabel style={{
+            minWidth: '10rem',
+            color: field.isValidated ? 'black' : 'pink',
+          }}
+          >
+            {fieldName}
+          </FormLabel>
+          <StyledButton
+            type="text"
+            size="middle"
+            textcolor="lightBlue"
+            style={{ minWidth: '5rem' }}
+          >
+            <label htmlFor={fieldId}>
+              <UploadBox />
+            </label>
+          </StyledButton>
+          <FormInput
+            type={fieldType}
+            id={fieldId}
+            name={fieldName}
+            onChange={(e) => handleDrop(e, fieldId, field.space_delimited, field.upload_max)}
+          />
+          <FormInput
+            type="text"
+            id={fieldId}
+            name={fieldName}
+            value={value.value}
+            defaultChecked={boolDefault}
+            onChange={(e) => handleChange(e)}
+          />
+          <AppDropdown overlay={menu} trigger="click">
+            <QmarkOutlined />
+          </AppDropdown>
+        </UploadZone>
       </>
     );
   }
@@ -310,11 +334,14 @@ FormBuilder.propTypes = {
     description: PropTypes.string.isRequired,
     choices: PropTypes.string.isRequired,
     isValidated: PropTypes.bool.isRequired,
+    space_delimited: PropTypes.bool.isRequired,
+    upload_max: PropTypes.number.isRequired,
   }).isRequired,
   fieldName: PropTypes.string.isRequired,
   fieldId: PropTypes.string.isRequired,
   handleChange: PropTypes.func.isRequired,
   handleChangeSelect: PropTypes.func.isRequired,
+  handleDrop: PropTypes.func.isRequired,
   value: PropTypes.shape({
     value: PropTypes.oneOfType([
       PropTypes.string,

--- a/src/containers/pipelines/pipeline-runs/pipeline-form/pipelineForm.js
+++ b/src/containers/pipelines/pipeline-runs/pipeline-form/pipelineForm.js
@@ -21,7 +21,7 @@ const PipelineFormStyled = styled.form`
 const DEFAULT_STATE = {};
 
 const PipelineForm = ({
-  config, formType, onInputFormSubmit, handleFormFieldUpload, uploadedCsv,
+  config, formType, onInputFormSubmit, handleFormFieldUpload, uploadedCsv, onInputsChangedOrDropped,
 }) => {
   const [fType, setFormType] = useState(undefined);
   const [fName, setFormName] = useState(undefined);
@@ -58,6 +58,12 @@ const PipelineForm = ({
         }
         if (cleanConfig[item].choices === undefined) {
           cleanConfig[item].choices = '';
+        }
+        if (cleanConfig[item].space_delimited !== true) {
+          cleanConfig[item].space_delimited = false;
+        }
+        if (cleanConfig[item].upload_max === undefined) {
+          cleanConfig[item].upload_max = 0;
         }
         if (cleanConfig[item].input_type.includes('required')) {
           cleanConfig[item].required = true;
@@ -102,17 +108,6 @@ const PipelineForm = ({
     if (config[e.target.id].input_type === 'boolean') {
       update = `${e.target.checked}`;
     }
-    if ((config[e.target.id].input_type === 'upload') || (config[e.target.id].input_type === 'upload required')) {
-      if (e.target.files) {
-        const [file] = e.target.files;
-        update = file.name;
-        handleFormFieldUpload(e);
-      } else if (e.dataTransfer) {
-        const [file] = e.dataTransfer.files;
-        update = file.name;
-        handleFormFieldUpload(e);
-      }
-    }
     dispatch({
       type: 'HANDLE INPUT TEXT',
       field: e.target.id,
@@ -135,6 +130,41 @@ const PipelineForm = ({
       type: 'HANDLE INPUT TEXT',
       field: id,
       payload: input,
+    });
+  };
+
+  const handleDrop = (e, id, space, max) => {
+    let update = '';
+    const files = Array.from(e.target.files || e.dataTransfer.files);
+    if (max) {
+      if (max === 1) {
+        update = files[0].name;
+      } else {
+        for (let i = 0; i < max; i += 1) {
+          if (i === (max - 1)) {
+            update += files[i].name;
+          } else if (space) {
+            update += `${files[i].name} `;
+          } else {
+            update += `${files[i].name}, `;
+          }
+        }
+      }
+      handleFormFieldUpload(e, max);
+    } else {
+      onInputsChangedOrDropped(e);
+      for (let i = 0; i < files.length; i += 1) {
+        if (space) {
+          update += `${files[i].name} `;
+        } else {
+          update += `${files[i].name}, `;
+        }
+      }
+    }
+    dispatch({
+      type: 'HANDLE INPUT TEXT',
+      field: id,
+      payload: update,
     });
   };
 
@@ -279,6 +309,7 @@ const PipelineForm = ({
                 handleChange={handleChange}
                 handleChangeSelect={handleChangeSelect}
                 handleFormFieldUpload={handleFormFieldUpload}
+                handleDrop={handleDrop}
               />
             );
           })}
@@ -298,6 +329,7 @@ PipelineForm.propTypes = {
   }).isRequired,
   onInputFormSubmit: PropTypes.func.isRequired,
   handleFormFieldUpload: PropTypes.func.isRequired,
+  onInputsChangedOrDropped: PropTypes.func.isRequired,
   formType: PropTypes.arrayOf(PropTypes.string).isRequired,
   uploadedCsv: PropTypes.arrayOf(PropTypes.array).isRequired,
 };

--- a/src/containers/pipelines/pipeline-runs/pipeline-form/pipelineForm.js
+++ b/src/containers/pipelines/pipeline-runs/pipeline-form/pipelineForm.js
@@ -73,6 +73,7 @@ const PipelineForm = ({
           cleanConfig[item].isValidated = true;
         }
         cleanConfig[item].value = cleanConfig[item].default;
+        cleanConfig[item].isOverMax = false;
         return item;
       });
       dispatch({
@@ -137,6 +138,19 @@ const PipelineForm = ({
     let update = '';
     const files = Array.from(e.target.files || e.dataTransfer.files);
     if (max) {
+      if (files.length > max) {
+        dispatch({
+          type: 'DROPPED OVER MAXIMUM ALLOWED',
+          field: id,
+          payload: true,
+        });
+      } else {
+        dispatch({
+          type: 'DROPPED OVER MAXIMUM ALLOWED',
+          field: id,
+          payload: false,
+        });
+      }
       if (max === 1) {
         update = files[0].name;
       } else {

--- a/src/reducers/configform.js
+++ b/src/reducers/configform.js
@@ -20,6 +20,15 @@ const formReducer = (state, action) => {
         },
       };
     }
+    case 'DROPPED OVER MAXIMUM ALLOWED': {
+      return {
+        ...state,
+        [action.field]: {
+          ...state[action.field],
+          isOverMax: action.payload,
+        },
+      };
+    }
     case 'HANDLE INITIAL UPDATE': {
       return {
         ...action.payload,


### PR DESCRIPTION
This pull request addresses issue #114 

# Issues

1. Upload fields were dedicated to single-file uploads and not multiple files
2. Upload fields did not accept drag-and-drop files
3. Upload fields needed support for comma delimiting or space delimiting

# Fixes

1. Implemented multiple file upload, default is unlimited, upload_max field in manifest can designate maximum allowable uploads (integer values)
2. Implemented drag-and-drop into the form fields, added color to text input background on-drag-over and if over maximum allowable for the field
3. Added default comma delimiting for the fields, if space_delimited is set to true in manifest, then fields will use space delimiting